### PR TITLE
Replace text attribute with full_text if the extended Tweet has no text set

### DIFF
--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -29,6 +29,15 @@ module Twitter
     predicate_attr_reader :favorited, :possibly_sensitive, :retweeted,
                           :truncated
 
+    # Initializes a new object
+    #
+    # @param attrs [Hash]
+    # @return [Twitter::Tweet]
+    def initialize(attrs = {})
+      attrs[:text] = attrs[:full_text] if attrs[:text].nil? && !attrs[:full_text].nil?
+      super
+    end
+
     # @note May be > 280 characters.
     # @return [String]
     def full_text

--- a/spec/twitter/tweet_spec.rb
+++ b/spec/twitter/tweet_spec.rb
@@ -92,6 +92,11 @@ describe Twitter::Tweet do
       expect(tweet.full_text).to be_a String
       expect(tweet.full_text).to eq('BOOSH')
     end
+    it 'returns the text of an extended Tweet' do
+      tweet = Twitter::Tweet.new(id: 28_669_546_014, text: nil, full_text: 'BOOSH')
+      expect(tweet.full_text).to be_a String
+      expect(tweet.full_text).to eq('BOOSH')
+    end
     it 'returns the text of a Tweet without a user' do
       tweet = Twitter::Tweet.new(id: 28_669_546_014, text: 'BOOSH', retweeted_status: {id: 28_561_922_517, text: 'BOOSH'})
       expect(tweet.full_text).to be_a String


### PR DESCRIPTION
https://github.com/sferik/twitter/pull/913/